### PR TITLE
[피드백] 관리자 페이지 #60에 대한 수정

### DIFF
--- a/src/features/admin/components/table/AdminItemTable.tsx
+++ b/src/features/admin/components/table/AdminItemTable.tsx
@@ -51,10 +51,7 @@ export const AdminItemTable = ({ adminHeaderData, adminBodyData }: Props) => {
             <td className='px-3 py-2'>{categoryFormat(item.itemCategory)}</td>
             <td>{item.itemName}</td>
             <td>
-              <Badge
-                className='w-full border-none px-0.5'
-                variant={statusVariantMap[item.itemStatus]}
-              >
+              <Badge variant={statusVariantMap[item.itemStatus]}>
                 {statusFormat(item.itemStatus)}
               </Badge>
             </td>

--- a/src/features/admin/components/table/AdminItemTable.tsx
+++ b/src/features/admin/components/table/AdminItemTable.tsx
@@ -55,12 +55,10 @@ export const AdminItemTable = ({ adminHeaderData, adminBodyData }: Props) => {
                 {statusFormat(item.itemStatus)}
               </Badge>
             </td>
-            <td className='text-sm font-medium'>
+            <td>
               {renderItemInfo(item.itemStatus, formatDate(item.returnDate))}
             </td>
-            <td className='text-sm font-medium'>
-              {renderItemInfo(item.itemStatus, item.rentalMemberName)}
-            </td>
+            <td>{renderItemInfo(item.itemStatus, item.rentalMemberName)}</td>
           </tr>
         ))}
       </tbody>

--- a/src/features/admin/mock/data/admin-item-detail.ts
+++ b/src/features/admin/mock/data/admin-item-detail.ts
@@ -1,6 +1,6 @@
 import { GetItemDetailResponse } from '../../apis';
 
-export const ITEM_DETAIL_MOCK: GetItemDetailResponse[] = [
+export const ADMIN_ITEM_DETAIL_MOCK: GetItemDetailResponse[] = [
   {
     rentalMemberName: '김해달',
     rentalMemberPhoneNumber: '010-1234-5678',

--- a/src/features/admin/mock/data/admin-items.ts
+++ b/src/features/admin/mock/data/admin-items.ts
@@ -1,6 +1,6 @@
 import { GetItemListResponse } from '../../apis';
 
-export const ITEMS_MOCK: GetItemListResponse[] = [
+export const ADMIN_ITEMS_MOCK: GetItemListResponse[] = [
   {
     itemCategory: 'BOOK',
     itemName: '자바스크립트 딥 다이브',

--- a/src/features/admin/mock/data/index.ts
+++ b/src/features/admin/mock/data/index.ts
@@ -1,2 +1,2 @@
-export * from './items';
-export * from './item-detail';
+export * from './admin-items';
+export * from './admin-item-detail';

--- a/src/features/admin/mock/handler/admin-Items.handler.ts
+++ b/src/features/admin/mock/handler/admin-Items.handler.ts
@@ -3,7 +3,7 @@ import { HttpResponse, http } from 'msw';
 import { BASE_URL } from '@/shared';
 
 import { GET_ITEM_LIST_PATH } from '../../apis';
-import { ITEMS_MOCK } from '../data';
+import { ADMIN_ITEMS_MOCK } from '../data';
 
 export const adminItemsHandler = [
   http.get(`${BASE_URL}${GET_ITEM_LIST_PATH}`, async ({ request }) => {
@@ -11,10 +11,10 @@ export const adminItemsHandler = [
     const itemStatus = url.searchParams.get('itemStatus');
 
     if (!itemStatus) {
-      return HttpResponse.json(ITEMS_MOCK);
+      return HttpResponse.json(ADMIN_ITEMS_MOCK);
     }
 
-    const filteredItems = ITEMS_MOCK.filter(
+    const filteredItems = ADMIN_ITEMS_MOCK.filter(
       (item) => item.itemStatus === itemStatus,
     );
 

--- a/src/features/admin/mock/handler/admin-item-list.handler.ts
+++ b/src/features/admin/mock/handler/admin-item-list.handler.ts
@@ -3,10 +3,10 @@ import { HttpResponse, http } from 'msw';
 import { BASE_URL } from '@/shared';
 
 import { GET_ITEM_LIST_PATH } from '../../apis';
-import { ITEMS_MOCK } from '../data';
+import { ADMIN_ITEMS_MOCK } from '../data';
 
 export const adminItemListHandler = [
   http.get(`${BASE_URL}${GET_ITEM_LIST_PATH}`, async () => {
-    return HttpResponse.json(ITEMS_MOCK);
+    return HttpResponse.json(ADMIN_ITEMS_MOCK);
   }),
 ];

--- a/src/features/admin/mock/handler/item-detail.handler.ts
+++ b/src/features/admin/mock/handler/item-detail.handler.ts
@@ -3,7 +3,7 @@ import { HttpResponse, http } from 'msw';
 import { BASE_URL } from '@/shared';
 
 import { GET_ITEM_DETAIL_PATH } from '../../apis';
-import { ITEM_DETAIL_MOCK } from '../data';
+import { ADMIN_ITEM_DETAIL_MOCK } from '../data';
 
 export const itemDetailHandler = [
   http.get(
@@ -18,7 +18,7 @@ export const itemDetailHandler = [
         );
       }
 
-      const itemDetail = ITEM_DETAIL_MOCK.find(
+      const itemDetail = ADMIN_ITEM_DETAIL_MOCK.find(
         (item) => item.itemId === itemId,
       );
 

--- a/src/features/admin/model/data/admin-item-data.ts
+++ b/src/features/admin/model/data/admin-item-data.ts
@@ -12,7 +12,7 @@ export const ADMIN_ITEM_HEADERS = [
     value: 'status',
   },
   {
-    text: '대여일',
+    text: '반납 기한',
     value: 'date',
   },
   {

--- a/src/features/admin/model/schema/add-item.ts
+++ b/src/features/admin/model/schema/add-item.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const AddItemSchema = z.object({
   name: z.string().min(1, { message: '물품 이름을 작성해주세요.' }),
-  type: z.enum(['book', 'boardGame', 'stationery', 'etc']),
+  type: z.enum(['BOOK', 'BOARD_GAME', 'OFFICE_SUPPLY', 'ETC']),
   approved: z.literal(true, {
     errorMap: () => ({ message: '체크 이후에 물품 추가가 가능합니다.' }),
   }),

--- a/src/features/admin/ui/container/ItemTypeContainer.tsx
+++ b/src/features/admin/ui/container/ItemTypeContainer.tsx
@@ -14,7 +14,7 @@ export const ItemTypeContainer = ({ itemType }: Props) => {
         {ITEM_TYPE.map((item) => (
           <Badge
             key={item.value}
-            variant={itemType === item.type ? 'available' : 'outline'}
+            variant={itemType === item.type ? 'unavailable' : 'available'}
           >
             {item.type}
           </Badge>

--- a/src/features/admin/ui/form/AddItemForm.tsx
+++ b/src/features/admin/ui/form/AddItemForm.tsx
@@ -46,7 +46,7 @@ export const AddItemForm = () => {
       <Form {...form}>
         <form
           onSubmit={(e) => e.preventDefault()}
-          className='flex w-full flex-col px-5 text-start'
+          className='flex w-full flex-col px-3 text-start'
         >
           <div className='flex flex-col gap-8 py-3'>
             <ItemField name='name' label='대여 물품의 이름을 작성해주세요.'>

--- a/src/features/admin/ui/form/AddItemForm.tsx
+++ b/src/features/admin/ui/form/AddItemForm.tsx
@@ -24,7 +24,7 @@ export const AddItemForm = () => {
     mode: 'onChange',
     defaultValues: {
       name: '',
-      type: 'book',
+      type: 'BOOK',
       approved: undefined,
     },
   });

--- a/src/features/admin/ui/section/ItemTypeSection.tsx
+++ b/src/features/admin/ui/section/ItemTypeSection.tsx
@@ -14,7 +14,7 @@ export const ItemTypeSection = ({ itemType }: Props) => {
         {ITEM_TYPE.map((item) => (
           <Badge
             key={item.value}
-            variant={itemType === item.type ? 'available' : 'outline'}
+            variant={itemType === item.type ? 'unavailable' : 'available'}
           >
             {item.type}
           </Badge>

--- a/src/features/apply-form/components/form/RentalPeriodField.tsx
+++ b/src/features/apply-form/components/form/RentalPeriodField.tsx
@@ -59,7 +59,7 @@ export const RentalPeriodField = () => {
               대여 기간은 대여일(<b>{getAfterDays(0)}</b>)로부터 최대 7일입니다.
             </p>
             <p>
-              (반납 마감일: <b>{AddDateformat(new Date(), 7)}</b>)
+              (반납 기한: <b>{AddDateformat(new Date(), 7)}</b>)
             </p>
           </div>
           <FormControl>

--- a/src/features/my-rental/components/MyRentalTable.tsx
+++ b/src/features/my-rental/components/MyRentalTable.tsx
@@ -46,7 +46,7 @@ export const MyRentalTable = ({ headerData, bodyData }: Props) => {
               <td>{item.name}</td>
               <td>{item.dueDate}</td>
               <td>
-                <Badge variant={item.isOverdue ? 'unavailable' : 'available'}>
+                <Badge variant={item.isOverdue ? 'overdue' : 'unavailable'}>
                   {item.isOverdue ? '기한 초과' : '이용 중'}
                 </Badge>
               </td>

--- a/src/pages/admin/RentedItemDetailPage.tsx
+++ b/src/pages/admin/RentedItemDetailPage.tsx
@@ -14,11 +14,15 @@ import { ButtonContainer, ContentsContainer, PageWrapper } from '@/widgets';
 export const RentedItemDetailPage = () => {
   const { itemId } = useParams();
 
-  const { data: itemData, isPending } = useGetItemDetail({
+  const {
+    data: itemData,
+    isPending,
+    isError,
+  } = useGetItemDetail({
     itemId: itemId ?? '',
   });
 
-  if (!itemData) {
+  if (!itemData || isError) {
     return <div>에러 발생</div>;
   }
 

--- a/src/shared/components/ui/badge.tsx
+++ b/src/shared/components/ui/badge.tsx
@@ -3,29 +3,25 @@ import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps, cva } from 'class-variance-authority';
 
-import { cn } from '@/shared';
-
 const badgeVariants = cva(
   'inline-flex items-center justify-center border px-4 py-1 text-sm font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {
-        available: 'bg-moon text-foreground [a&]:hover:bg-moon/90',
-        unavailable:
+        available:
+          'border border-haedal text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        unavailable: 'bg-moon text-foreground [a&]:hover:bg-moon/90',
+        overdue:
           'bg-sun text-white [a&]:hover:bg-sun/90 focus-visible:ring-sun/20 dark:focus-visible:ring-sun/40 dark:bg-sun/70',
-        wait: 'bg-haedal text-white [a&]:hover:bg-haedal/90',
-        outline:
-          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
       },
     },
     defaultVariants: {
-      variant: 'outline',
+      variant: 'available',
     },
   },
 );
 
 function Badge({
-  className,
   variant,
   asChild = false,
   ...props
@@ -34,11 +30,7 @@ function Badge({
   const Comp = asChild ? Slot : 'span';
 
   return (
-    <Comp
-      data-slot='badge'
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
+    <Comp data-slot='badge' className={badgeVariants({ variant })} {...props} />
   );
 }
 

--- a/src/shared/utils/format/status-format/status-format.ts
+++ b/src/shared/utils/format/status-format/status-format.ts
@@ -13,12 +13,12 @@ export const statusFormat = (status: string) => {
 
 export const statusVariantMap: Record<
   ItemStatus,
-  'available' | 'unavailable' | 'outline' | 'wait'
+  'available' | 'unavailable' | 'overdue'
 > = {
   RENTAL_AVAILABLE: 'available',
   RENTING: 'unavailable',
-  RENTAL_OVERDUE: 'unavailable',
-  OVERDUE: 'unavailable',
-  RENTAL_WAITING: 'wait',
+  RENTAL_OVERDUE: 'overdue',
+  OVERDUE: 'overdue',
+  RENTAL_WAITING: 'unavailable',
   '': 'available',
 };


### PR DESCRIPTION
## 📝 상세 내용
- [x] 물품 추가 페이지 대소문자 오류 수정
- [x] padding 값 수정
- [x] 오류는 아닌데 UI상 '물품 추가' 버튼이 '뒤로'와 함께 있는 게 맞을 것 같거든요
이 페이지에서만 CTA(콜 투 액션) 버튼이 컨테이너 안에 있는 게 이상...
그래서 고치는 건 어떻게 생각하세요??
→ form 특성상 어려울것 같아요. (우선순위 낮아보임)

## #️⃣ 이슈 번호
- closes #61 

## 💬 리뷰 요구사항
### 물품 상세 페이지와 리스트에 나타나는 물품이 다른 이슈
![image](https://github.com/user-attachments/assets/08a61e5e-020c-4a1c-bd57-66d254705880)

![image](https://github.com/user-attachments/assets/46d2dba0-45ae-44b2-bc2c-3e2a2dc6ffe5)

mock data가 달라서 그렇것 같아요. 목록에서는 itemId 가 1번일때 js deep dive를 가리키고 있는데 detail 에서는 react deep dive를 가리키고 있네요.

api 연결하면 정상 동작합니다!
(db에 저장된 itemId에 따라 동일한 데이터를 가져오기 때문)
## ⏰ 현재 버그


## 📷 스크린샷(선택)


## 🔗 참고 자료(선택)

